### PR TITLE
Correct from/to in pending transactions

### DIFF
--- a/components/transactionDetail/pending/PendingTransactionFromAPI.tsx
+++ b/components/transactionDetail/pending/PendingTransactionFromAPI.tsx
@@ -85,12 +85,12 @@ const PendingTransactionFromAPI: React.FC<{ txId: string }> = ({ txId }) => {
             timestamp,
           },
           fromAccount: {
-            id: receiver,
-            address: withdrawalInfo.recipient,
-          },
-          toAccount: {
             id: storageInfo.accountId,
             address: senderAddress,
+          },
+          toAccount: {
+            id: receiver,
+            address: receiverAddress,
           },
           token: {
             symbol,


### PR DESCRIPTION
The explorer displays from/to swapped while a transaction is pending. This fixes that.