### PR TITLE
Add support for support for `image/webp` in NFTAnimation

### DIFF
--- a/components/nftDetail/NFTAnimation.tsx
+++ b/components/nftDetail/NFTAnimation.tsx
@@ -65,6 +65,8 @@ const NFTAnimation: React.FC<{ animationURL: string; animationType: string; imag
         />
       </>
     );
+  } else if (animationType?.startsWith('image/webp')) {
+    return <FallBackImg fallBackSrc={fallBackImage} src={animationURL as string} />;
   } else {
     return <FallBackImg fallBackSrc={fallBackImage} src={image as string} />;
   }


### PR DESCRIPTION
This pull request introduces support for `image/webp` in NFTAnimation. It includes the following changes:

- Added a condition to check if the animation type starts with 'image/webp'.
- If the condition is met, it renders the `<FallBackImg>` component with the appropriate source URLs.

This enhancement improves compatibility with the `image/webp` format, allowing NFTAnimation to display animations in this format when applicable.
